### PR TITLE
Entity large 414

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,10 +19,10 @@ void main() async {
   usePathUrlStrategy();
   await dotenv.load(fileName: ".env");
   await KindeFlutterSDK.initializeSDK(
-      authDomain: dotenv.env['KINDE_AUTH_DOMAIN']!,
-      authClientId: dotenv.env['KINDE_AUTH_CLIENT_ID']!,
-      loginRedirectUri: dotenv.env['KINDE_LOGIN_REDIRECT_URI']!,
-      logoutRedirectUri: dotenv.env['KINDE_LOGOUT_REDIRECT_URI']!,
+      authDomain: "https://talibandsons.kinde.com",
+      authClientId: "8aca0a6f25724c6d95ba1afd5d9e3945",
+      loginRedirectUri: "com.kinde.myapp://kinde_callback",
+      logoutRedirectUri: "com.kinde.myapp://kinde_logoutcallback",
       scopes: ["email", "profile", "offline", "openid"] // optional
       );
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,10 +19,10 @@ void main() async {
   usePathUrlStrategy();
   await dotenv.load(fileName: ".env");
   await KindeFlutterSDK.initializeSDK(
-      authDomain: "https://talibandsons.kinde.com",
-      authClientId: "8aca0a6f25724c6d95ba1afd5d9e3945",
-      loginRedirectUri: "com.kinde.myapp://kinde_callback",
-      logoutRedirectUri: "com.kinde.myapp://kinde_logoutcallback",
+      authDomain: dotenv.env['KINDE_AUTH_DOMAIN']!,
+      authClientId: dotenv.env['KINDE_AUTH_CLIENT_ID']!,
+      loginRedirectUri: dotenv.env['KINDE_LOGIN_REDIRECT_URI']!,
+      logoutRedirectUri: dotenv.env['KINDE_LOGOUT_REDIRECT_URI']!,
       scopes: ["email", "profile", "offline", "openid"] // optional
       );
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
 
   kinde_flutter_sdk:
     path: ../../kinde-flutter-sdk
+  flutter_appauth: ^10.0.0
   url_launcher: ^6.1.11
   hive: ^2.2.3
   flutter_secure_storage: ^8.0.0

--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -226,8 +226,7 @@ class KindeFlutterSDK with TokenUtils {
       await _handleNonWebLogout(
           dio: dio,
           macosLogoutWithoutRedirection: macosLogoutWithoutRedirection,
-          timeout: timeout
-      );
+          timeout: timeout);
     }
 
     await _commonLogoutCleanup();
@@ -247,7 +246,9 @@ class KindeFlutterSDK with TokenUtils {
       final endSessionRequest = EndSessionRequest(
           externalUserAgent:
               ExternalUserAgent.ephemeralAsWebAuthenticationSession,
-          idTokenHint: authState!.idToken,
+          idTokenHint: (authState!.idToken?.length ?? 0) > 100
+              ? authState!.idToken!.substring(0, 100)
+              : authState!.idToken,
           postLogoutRedirectUrl: _config!.logoutRedirectUri,
           serviceConfiguration: _serviceConfiguration,
           additionalParameters: _config != null
@@ -256,7 +257,9 @@ class KindeFlutterSDK with TokenUtils {
 
       await appAuth.endSession(endSessionRequest).timeout(timeout,
           onTimeout: () {
-        throw const KindeError(code: KindeErrorCode.requestTimedOut, message: 'Logout request timed out');
+        throw const KindeError(
+            code: KindeErrorCode.requestTimedOut,
+            message: 'Logout request timed out');
       });
     } catch (e, st) {
       kindeDebugPrint(methodName: "Logout", message: e.toString());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
 
-  flutter_appauth: ^8.0.3
+  flutter_appauth: ^10.0.0
   hive: ^2.2.3
   flutter_secure_storage: ^8.0.0
   path_provider: ^2.0.15


### PR DESCRIPTION
# Explain your changes

There was an issue related to the large ID token (414). We are using the flutter_appauth library for authentication. On iOS, flutter_appauth does not require the ID token (it can be empty but not null). However, on Android, the ID token must not be null and must not be empty. Because of this, I did not remove it from the request completely; instead, I truncated it to 100 characters. I also updated the flutter_appauth library to the latest version.


1- First Code change in **kinde_flutter_sdk** file in the **_handleNonWebLogout** function
    idTokenHint: (authState!.idToken?.length ?? 0) > 100
              ? authState!.idToken!.substring(0, 100)
              : authState!.idToken,

2-Second Code level change

-    Updated the flutter_appauth library to the latest version **flutter_appauth**: ^10.0.0 in the sdk pubspec.yaml file and example's pubspec.yaml file 


# Checklist

- [ checked] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [checked] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
