### PR TITLE
Update Android example app build tools and pubspec path reference

### DIFF
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,2 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
   id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-  id "com.android.application" version '8.7.3' apply false
-  id "org.jetbrains.kotlin.android" version "1.9.24" apply false
+  id "com.android.application" version '8.9.1' apply false
+  id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ':app'

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
     sdk: flutter
 
   kinde_flutter_sdk:
-    path: ../../kinde-flutter-sdk
+    path: ../
   url_launcher: ^6.3.1
   flutter_secure_storage: ^9.0.0
   jwt_decoder: ^2.0.1


### PR DESCRIPTION
## Changes:

- Fix path reference in example pubspec.yaml for local SDK dependency
- Update Android build tools: AGP 8.7.3→8.9.1, Kotlin 1.9.24→2.1.0, Gradle 8.9→8.11.1 for android compatibility