### PR TITLE
fix: replace id_token_hint with client_id on logout request to fix 414 Request-URI Too Large error

### DIFF
--- a/lib/src/auth/kinde_end_session_request.dart
+++ b/lib/src/auth/kinde_end_session_request.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_appauth/flutter_appauth.dart';
+
+/// A custom [EndSessionRequest] implementation used to bypass
+/// `flutter_appauth`'s [EndSessionRequest] assertion that requires both
+/// [idTokenHint] and [postLogoutRedirectUrl] to be either both null or both
+/// non-null.
+///
+/// This is required so we can omit [idTokenHint] when we pass the
+/// [postLogoutRedirectUrl]. We now pass the [client_id] as part of
+/// [additionalParameters] instead.
+///
+/// Omitting [idTokenHint] prevents 414 Request-URI Too Large errors caused by
+/// appending a potentially large idToken to the logout URL.
+///
+/// TODO: This class should be removed when `flutter_appauth` removes its
+/// assertions, so we can use [EndSessionRequest] directly.
+/// See https://github.com/MaikuB/flutter_appauth/pull/585.
+class KindeEndSessionRequest implements EndSessionRequest {
+  @override
+  final String? idTokenHint;
+  @override
+  final String? postLogoutRedirectUrl;
+  @override
+  final String? state;
+  @override
+  bool allowInsecureConnections;
+  @override
+  ExternalUserAgent? externalUserAgent;
+  @override
+  final Map<String, String>? additionalParameters;
+  @override
+  AuthorizationServiceConfiguration? serviceConfiguration;
+  @override
+  String? issuer;
+  @override
+  String? discoveryUrl;
+
+  KindeEndSessionRequest({
+    this.idTokenHint,
+    this.postLogoutRedirectUrl,
+    this.state,
+    this.allowInsecureConnections = false,
+    this.externalUserAgent = ExternalUserAgent.asWebAuthenticationSession,
+    this.additionalParameters,
+    this.serviceConfiguration,
+    this.issuer,
+    this.discoveryUrl,
+  });
+
+  @override
+  void assertConfigurationInfo() {
+    assert(
+      issuer != null || discoveryUrl != null || serviceConfiguration != null,
+      'Either the issuer, discovery URL or service configuration must be '
+      'provided',
+    );
+  }
+}

--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:kinde_flutter_sdk/src/additional_params.dart';
+import 'package:kinde_flutter_sdk/src/auth/kinde_end_session_request.dart';
 import 'package:kinde_flutter_sdk/src/kinde_secure_storage/kinde_secure_storage_i.dart';
 import 'package:kinde_flutter_sdk/src/utils/kinde_custom_types.dart';
 import 'package:kinde_flutter_sdk/src/utils/kinde_debug_print.dart';
@@ -282,22 +283,19 @@ class KindeFlutterSDK with TokenUtils {
 
     try {
       const appAuth = FlutterAppAuth();
-      // EndSessionRequest parameters:
-      // - externalUserAgent: Uses ASWebAuthenticationSession (iOS) / Custom Tabs (Android)
-      //   for secure browser-based logout flow
-      // - idTokenHint: Required for org-specific logout in multi-org scenarios (OIDC recommended)
-      // - postLogoutRedirectUrl: Where to redirect user after logout (OIDC post_logout_redirect_uri)
-      // - serviceConfiguration: Contains the logout endpoint URL
+      // To prevent "414 Request-URI Too Large" errors caused by appending a massive
+      // idToken to the logout URL, we do not pass `idTokenHint` with the `postLogoutRedirectUrl`.
       //
-      // NOTE: Removed redundant additionalParameters["redirect"] - postLogoutRedirectUrl
-      // already handles the redirect via standard OIDC post_logout_redirect_uri parameter.
-      // This reduces URL length and follows OIDC spec more closely.
-      final endSessionRequest = EndSessionRequest(
-          externalUserAgent:
-              ExternalUserAgent.ephemeralAsWebAuthenticationSession,
-          idTokenHint: authState!.idToken,
-          postLogoutRedirectUrl: _config!.logoutRedirectUri,
-          serviceConfiguration: _serviceConfiguration);
+      // We instead pass the `client_id` as part of `additionalParameters`.
+      //
+      // See the [KindeEndSessionRequest] class documentation for more information.
+      final endSessionRequest = KindeEndSessionRequest(
+        externalUserAgent:
+            ExternalUserAgent.ephemeralAsWebAuthenticationSession,
+        postLogoutRedirectUrl: _config?.logoutRedirectUri,
+        serviceConfiguration: _serviceConfiguration,
+        additionalParameters: {'client_id': _config!.authClientId},
+      );
 
       await appAuth.endSession(endSessionRequest).timeout(timeout,
           onTimeout: () {

--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -292,7 +292,7 @@ class KindeFlutterSDK with TokenUtils {
       final endSessionRequest = KindeEndSessionRequest(
         externalUserAgent:
             ExternalUserAgent.ephemeralAsWebAuthenticationSession,
-        postLogoutRedirectUrl: _config?.logoutRedirectUri,
+        postLogoutRedirectUrl: _config!.logoutRedirectUri,
         serviceConfiguration: _serviceConfiguration,
         additionalParameters: {'client_id': _config!.authClientId},
       );

--- a/test/src/auth/kinde_end_session_request_test.dart
+++ b/test/src/auth/kinde_end_session_request_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_appauth/flutter_appauth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kinde_flutter_sdk/src/auth/kinde_end_session_request.dart';
+
+void main() {
+  group("KindeEndSessionRequest", () {
+    group("constructor", () {
+      test("does not throw assertion error if both "
+          "idTokenHint and postLogoutRedirectUrl are null", () {
+        expect(
+          () => KindeEndSessionRequest(
+            idTokenHint: null,
+            postLogoutRedirectUrl: null,
+          ),
+          isNot(throwsAssertionError),
+        );
+      });
+
+      test("does not throw assertion error if idTokenHint is non-null but "
+          "postLogoutRedirectUrl is null", () {
+        expect(
+          () => KindeEndSessionRequest(
+            idTokenHint: 'idTokenHint',
+            postLogoutRedirectUrl: null,
+          ),
+          isNot(throwsAssertionError),
+        );
+      });
+
+      test(
+        "does not throw assertion error if postLogoutRedirectUrl is non-null but "
+        "idTokenHint is null",
+        () {
+          expect(
+            () => KindeEndSessionRequest(
+              idTokenHint: null,
+              postLogoutRedirectUrl: 'postLogoutRedirectUrl',
+            ),
+            isNot(throwsAssertionError),
+          );
+        },
+      );
+
+      test("does not throw assertion error if both "
+          "idTokenHint and postLogoutRedirectUrl are non-null", () {
+        expect(
+          () => KindeEndSessionRequest(
+            idTokenHint: 'idTokenHint',
+            postLogoutRedirectUrl: 'postLogoutRedirectUrl',
+          ),
+          isNot(throwsAssertionError),
+        );
+      });
+    });
+
+    group("assertConfigurationInfo", () {
+      test("throws exception if no configuration "
+          "information is provided", () {
+        expect(
+          () => KindeEndSessionRequest().assertConfigurationInfo(),
+          throwsAssertionError,
+        );
+      });
+
+      test("does not throw exception if issuer is provided", () {
+        expect(
+          () => KindeEndSessionRequest(
+            issuer: 'issuer',
+          ).assertConfigurationInfo(),
+          isNot(throwsAssertionError),
+        );
+      });
+
+      test("does not throw exception if discoveryUrl is provided", () {
+        expect(
+          () => KindeEndSessionRequest(
+            discoveryUrl: 'discoveryUrl',
+          ).assertConfigurationInfo(),
+          isNot(throwsAssertionError),
+        );
+      });
+
+      test("does not throw exception if serviceConfiguration is provided", () {
+        expect(
+          () => KindeEndSessionRequest(
+            serviceConfiguration: const AuthorizationServiceConfiguration(
+              authorizationEndpoint: 'authorizationEndpoint',
+              tokenEndpoint: 'tokenEndpoint',
+            ),
+          ).assertConfigurationInfo(),
+          isNot(throwsAssertionError),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
# Explain your changes

This PR updates the logout function for non-web platforms in the SDK to use a combination of `client_id` and `post_logout_redirect_uri` instead of the previous combination of `id_token_hint` and `post_logout_redirect_uri`. 

See [OIDC RP-Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout).

The reason for this change is a situation where a user has a large number of claims (orgs, roles, permissions...), which makes their `id_token` large and causes the logout redirection to fail with `414 Request-URI Too Large` when the id token is passed as the `id_token_hint` for the logout request. 

**New class: KindeEndSessionRequest**

The existing `EndSessionRequest` from `flutter_appauth` throws [assertion errors](https://github.com/MaikuB/flutter_appauth/blob/4e0932199b57b595b6f0bed0e46100ed3dda7f09/flutter_appauth_platform_interface/lib/src/end_session_request.dart#L16-L17) when the `idTokenHint` parameter is null and `postLogoutRedirectUrl` parameter is set. 

To fix that, I created a custom class, `KindeEndSessionRequest`, that implements `EndSessionRequest` in order to bypass the assertions so the logout function can pass `postLogoutRedirectUrl` without setting the `idTokenHint`. 

Related:
- https://github.com/kinde-oss/kinde-flutter-sdk/pull/56
- https://github.com/kinde-oss/kinde-flutter-sdk/pull/40


# Screen recordings

Here are before and after screen recordings of a user profile with a large `id_token` attempting to sign out: 

## Before (logout fails): 
https://github.com/user-attachments/assets/4a35e88b-5c9f-4a9f-8e0b-34e9ccfd8f75

## After (logout succeeds):

https://github.com/user-attachments/assets/5a963eff-ecc3-47c7-8020-f2cb57e49f6a

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
