### PR TITLE
feat: fetch latest tokens from storage before token refresh

### DIFF
--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -608,7 +608,7 @@ class KindeFlutterSDK with TokenUtils {
     /// checks or refresh operations with the tokens.
     /// This is especially important for apps with concurrent background tasks
     /// using isolates that don't have access to the latest cached state
-    await _store.loadFromStorage();
+    await _store.reloadAuthState();
     _kindeApi.setBearerAuth(_bearerAuth, _store.authState?.accessToken ?? '');
 
     // Return existing token if authenticated and not forcing refresh

--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -609,10 +609,10 @@ class KindeFlutterSDK with TokenUtils {
     /// This is especially important for apps with concurrent background tasks
     /// using isolates that don't have access to the latest cached state
     await _store.reloadAuthState();
-    _kindeApi.setBearerAuth(_bearerAuth, _store.authState?.accessToken ?? '');
 
     // Return existing token if authenticated and not forcing refresh
     if (!forceRefresh && await isAuthenticated()) {
+      _kindeApi.setBearerAuth(_bearerAuth, _store.authState?.accessToken ?? '');
       return _store.authState?.accessToken;
     }
 

--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -604,6 +604,13 @@ class KindeFlutterSDK with TokenUtils {
   }
 
   Future<String?> getToken({bool forceRefresh = false}) async {
+    /// This is important to ensure we have the latest tokens before performing
+    /// checks or refresh operations with the tokens.
+    /// This is especially important for apps with concurrent background tasks
+    /// using isolates that don't have access to the latest cached state
+    await _store.loadFromStorage();
+    _kindeApi.setBearerAuth(_bearerAuth, _store.authState?.accessToken ?? '');
+
     // Return existing token if authenticated and not forcing refresh
     if (!forceRefresh && await isAuthenticated()) {
       return _store.authState?.accessToken;

--- a/lib/src/store/store.dart
+++ b/lib/src/store/store.dart
@@ -66,6 +66,10 @@ class Store {
     await _readKeys();
   }
 
+  Future<void> reloadAuthState() async {
+    await _readAuthState();
+  }
+
   Future<void> _readAuthState() async {
     try {
       final currentData = await _storage.read(key: _authStateKey);


### PR DESCRIPTION
# Explain your changes

This PR ensures that in `getToken` calls, the cached auth state is synced with the state from storage. 

This is to ensure the token is valid in cases where there are concurrent calls to `getToken`, which could previously fail as a result of one of the calls using an invalid cached token. 

### Unit tests: 
An internal task to add tests for this update has been created and will be implemented after #53 and #60 are merged in.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
