### PR TITLE
fix(web): use package:web so web auth works under dart2wasm (WebAssembly)

### DIFF
--- a/lib/src/kinde_web/src/utils/cross_platform_support.dart
+++ b/lib/src/kinde_web/src/utils/cross_platform_support.dart
@@ -1,2 +1,2 @@
 export 'cross_platform_support_noop.dart'
-    if (dart.library.html) 'web_utils.dart';
+    if (dart.library.js_interop) 'web_utils.dart';

--- a/lib/src/kinde_web/src/utils/web_utils.dart
+++ b/lib/src/kinde_web/src/utils/web_utils.dart
@@ -1,16 +1,16 @@
-import 'package:web/web.dart' as web;
+import 'package:web/web.dart';
 
 abstract class WebUtils {
   const WebUtils._();
 
-  static void openPage(String url) => web.window.location.assign(url);
+  static void openPage(String url) => window.location.assign(url);
 
-  static void replacePage(String url) => web.window.location.replace(url);
+  static void replacePage(String url) => window.location.replace(url);
 
-  static String? get getCurrentUrl => web.window.location.href;
+  static String? get getCurrentUrl => window.location.href;
 
-  static String? get getOriginUrl => web.window.location.origin;
+  static String? get getOriginUrl => window.location.origin;
 
   static String get temporaryDirectory =>
-      web.window.localStorage.getItem('temporary_directory') ?? "";
+      window.localStorage.getItem('temporary_directory') ?? "";
 }

--- a/lib/src/kinde_web/src/utils/web_utils.dart
+++ b/lib/src/kinde_web/src/utils/web_utils.dart
@@ -1,17 +1,16 @@
-// ignore_for_file: avoid_web_libraries_in_flutter
-
-import 'dart:html';
+import 'package:web/web.dart' as web;
 
 abstract class WebUtils {
   const WebUtils._();
 
-  static void openPage(String url) => window.location.assign(url);
+  static void openPage(String url) => web.window.location.assign(url);
 
-  static void replacePage(String url) => window.location.replace(url);
+  static void replacePage(String url) => web.window.location.replace(url);
 
-  static String? get getCurrentUrl => window.location.href;
+  static String? get getCurrentUrl => web.window.location.href;
 
-  static String? get getOriginUrl => window.location.origin;
+  static String? get getOriginUrl => web.window.location.origin;
 
-  static String get temporaryDirectory => window.localStorage['temporary_directory'] ?? "";
+  static String get temporaryDirectory =>
+      web.window.localStorage.getItem('temporary_directory') ?? "";
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -982,7 +982,7 @@ packages:
     source: hosted
     version: "1.2.1"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   built_collection: ^5.1.1
   http_mock_adapter: ^0.6.1
   app_links: ^7.0.0
+  web: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Background

As of **Flutter 3.44**, WebAssembly (dart2wasm + the skwasm renderer) is positioned as the **recommended build for production web apps** — see [What's new in Flutter 3.44](https://blog.flutter.dev/whats-new-in-flutter-3-44-b0cc1ad3c527) and the [Wasm support docs](https://docs.flutter.dev/platform-integration/web/wasm). That makes dart2wasm compatibility important for the SDK, and today the web OAuth flow breaks under wasm.

### Problem

`WebUtils` (the web OAuth navigation helper) is provided via a conditional export gated on `dart.library.html`:

```dart
export 'cross_platform_support_noop.dart'
    if (dart.library.html) 'web_utils.dart';
```

`dart.library.html` is **true on dart2js** but **false on dart2wasm** (`dart:html` doesn't exist there). So under wasm the export resolves to `cross_platform_support_noop.dart`, and every `WebUtils` method — including the OAuth redirect `replacePage` (`window.location.replace`) — becomes a **no-op**.

The result on a Flutter web app built with `--wasm`:
- `startLoginFlow` sets `_loginInProgress = true`, calls `WebOAuthFlow.login` → `WebUtils.replacePage(...)` which **does nothing** (no redirect to Kinde).
- The page never navigates away, so `_loginInProgress` never clears.
- The next login attempt throws `KindeErrorCode.loginInProcess` (`[login-in-process]`), and the user can never sign in.

### Fix

Port `web_utils.dart` from `dart:html` to **`package:web`**, and switch the conditional export to **`dart.library.js_interop`** (true on both dart2js *and* dart2wasm):

- `web_utils.dart`: `window.location.assign/replace`, `.href`, `.origin`, and `localStorage` now go through `package:web`.
- `cross_platform_support.dart`: `if (dart.library.html)` → `if (dart.library.js_interop)`.

Notes:
- **dart2js is unchanged** — `package:web` works there too, and `dart.library.js_interop` is true on dart2js, so the same `web_utils.dart` is selected.
- Non-web platforms still get `cross_platform_support_noop.dart` (`js_interop` is false on VM/native).

Verified: a Flutter app using this SDK compiles to `--wasm` and the OAuth redirect navigates correctly with this change (vs. silently no-op'ing before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)