### PR TITLE
Fix 'This link has expired' login errors from concurrent/duplicate authorization

### DIFF
--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -60,13 +60,14 @@ class KindeFlutterSDK with TokenUtils {
   bool _handlingInvitationCode = false;
   StreamSubscription<Uri>? _deepLinkSubscription;
 
-  /// The last invitation code that was processed by the deep-link listener.
+  /// The last invitation code successfully processed by the deep-link listener.
   ///
   /// The OS may re-deliver the same invitation deep link (app resume, link
   /// re-open, redelivery after a successful sign-in). Without this, each
   /// redelivery re-triggers `login()` with an already-consumed code, producing
-  /// the hosted "This link has expired" page. Cleared on logout so a fresh
-  /// invitation can be processed again.
+  /// the hosted "This link has expired" page. Set only after login succeeds so
+  /// transient failures can be retried. Cleared on logout so a fresh invitation
+  /// can be processed again.
   String? _lastHandledInvitationCode;
 
   /// Guards against concurrent native authorization flows.
@@ -789,7 +790,7 @@ class KindeFlutterSDK with TokenUtils {
 
           if (invitationCode == null || invitationCode.isEmpty) return;
 
-          _handleInvitationCode(invitationCode);
+          handleInvitationCode(invitationCode);
         }),
       );
     } catch (e) {
@@ -800,7 +801,9 @@ class KindeFlutterSDK with TokenUtils {
     }
   }
 
-  Future<void> _handleInvitationCode(String invitationCode) async {
+  /// Exposed for regression tests of invitation deep-link handling.
+  @visibleForTesting
+  Future<void> handleInvitationCode(String invitationCode) async {
     try {
       if (_handlingInvitationCode)  {
         kindeDebugPrint(
@@ -819,7 +822,6 @@ class KindeFlutterSDK with TokenUtils {
       }
 
       _handlingInvitationCode = true;
-      _lastHandledInvitationCode = invitationCode;
 
       kindeDebugPrint(
         methodName: "_handleInvitationCode",
@@ -829,6 +831,7 @@ class KindeFlutterSDK with TokenUtils {
       await login(
         additionalParams: AdditionalParameters(invitationCode: invitationCode),
       );
+      _lastHandledInvitationCode = invitationCode;
     } catch (e) {
       kindeDebugPrint(
         methodName: "_handleInvitationCode",

--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -60,6 +60,27 @@ class KindeFlutterSDK with TokenUtils {
   bool _handlingInvitationCode = false;
   StreamSubscription<Uri>? _deepLinkSubscription;
 
+  /// The last invitation code that was processed by the deep-link listener.
+  ///
+  /// The OS may re-deliver the same invitation deep link (app resume, link
+  /// re-open, redelivery after a successful sign-in). Without this, each
+  /// redelivery re-triggers `login()` with an already-consumed code, producing
+  /// the hosted "This link has expired" page. Cleared on logout so a fresh
+  /// invitation can be processed again.
+  String? _lastHandledInvitationCode;
+
+  /// Guards against concurrent native authorization flows.
+  ///
+  /// Only one browser-based authorize request may be in flight at a time. A
+  /// second concurrent request (e.g. a double-tap, an interrupted-and-retried
+  /// login, or the invitation deep-link listener firing while a user-initiated
+  /// login is already open) would start a new authorization with a fresh
+  /// `state`, superseding the first. When a redirect then completes against the
+  /// stale request the provider rejects it ("state did not match" client-side /
+  /// "This link has expired" on the hosted page). Mirrors the existing
+  /// `_loginInProgress` guard in the web flow.
+  bool _loginInProgress = false;
+
   static KindeFlutterSDK get instance {
     return _instance ??= KindeFlutterSDK._internal();
   }
@@ -251,6 +272,11 @@ class KindeFlutterSDK with TokenUtils {
     bool macosLogoutWithoutRedirection = true,
     Duration timeout = const Duration(seconds: 30),
   }) async {
+    // Always reset invitation dedup on logout, even when there is no active
+    // session. A failed invitation login (e.g. expired code) may never
+    // establish a session, so this must run before the early return below.
+    _lastHandledInvitationCode = null;
+
     if (authState == null) {
       kindeDebugPrint(methodName: 'logout', message: 'No active session');
       return;
@@ -416,6 +442,20 @@ class KindeFlutterSDK with TokenUtils {
   //MacOs, Android, IOS
   Future<String?> _handleOtherLogin(
     AuthFlowType? type, InternalAdditionalParameters params) async {
+    // Reject concurrent authorization attempts. Starting a second browser
+    // flow while one is already pending supersedes the first request's state
+    // and leads to "state did not match" / "This link has expired" errors.
+    if (_loginInProgress) {
+      kindeDebugPrint(
+        methodName: '_handleOtherLogin',
+        message: 'Authorization already in progress; ignoring concurrent request',
+      );
+      throw KindeError(
+        code: KindeErrorCode.loginInProcess.code,
+        message: 'An authentication flow is already in progress',
+      );
+    }
+    _loginInProgress = true;
     const appAuth = FlutterAppAuth();
     TokenResponse tokenResponse;
     try {
@@ -448,6 +488,8 @@ class KindeFlutterSDK with TokenUtils {
         context: {'flowType': type?.name ?? 'default', 'error': e.toString()},
       );
       throw KindeError.fromError(e, st);
+    } finally {
+      _loginInProgress = false;
     }
   }
 
@@ -768,7 +810,16 @@ class KindeFlutterSDK with TokenUtils {
         return;
       }
 
+      if (invitationCode == _lastHandledInvitationCode) {
+        kindeDebugPrint(
+          methodName: "_handleInvitationCode",
+          message: "Invitation code already handled previously. Skipping.",
+        );
+        return;
+      }
+
       _handlingInvitationCode = true;
+      _lastHandledInvitationCode = invitationCode;
 
       kindeDebugPrint(
         methodName: "_handleInvitationCode",

--- a/test/kinde_flutter_sdk_auth_concurrency_test.dart
+++ b/test/kinde_flutter_sdk_auth_concurrency_test.dart
@@ -1,0 +1,157 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kinde_flutter_sdk/kinde_flutter_sdk.dart';
+import 'package:kinde_flutter_sdk/src/kinde_flutter_sdk.dart';
+
+import 'mock_channels.dart';
+import 'test_helpers/dio_adapter.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const flutterAppauth =
+      MethodChannel('crossingthestreams.io/flutter_appauth');
+
+  group('native auth concurrency', () {
+    late Dio mockDio;
+
+    setUp(() async {
+      mockChannels.setupMockChannel();
+      mockDio = setupDioMock();
+      await initializeKindeFlutterSdkForTest(
+        authDomain: 'authDomain',
+        authClientId: 'authClientId',
+        loginRedirectUri: 'loginRedirectUri',
+        logoutRedirectUri: 'logoutRedirectUri',
+        dio: mockDio,
+      );
+    });
+
+    tearDown(() async {
+      await KindeFlutterSDK.instance.logout(dio: mockDio);
+    });
+
+    test('rejects overlapping login() with login-in-process', () async {
+      final releaseAuthorizeFlow = Completer<void>();
+
+      TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(flutterAppauth, (methodCall) async {
+        if (methodCall.method == 'authorizeAndExchangeCode') {
+          await releaseAuthorizeFlow.future;
+          return tokenResponseMap;
+        }
+        if (methodCall.method == 'authorize') {
+          return authorizeResponse;
+        }
+        if (methodCall.method == 'token') {
+          return tokenResponseMap;
+        }
+        if (methodCall.method == 'endSession') {
+          return endSessionResponse;
+        }
+        return null;
+      });
+
+      final firstLogin = KindeFlutterSDK.instance.login();
+      await Future<void>.delayed(Duration.zero);
+
+      await expectLater(
+        KindeFlutterSDK.instance.login(),
+        throwsA(
+          isA<KindeError>().having(
+            (error) => error.code,
+            'code',
+            KindeErrorCode.loginInProcess.code,
+          ),
+        ),
+      );
+
+      releaseAuthorizeFlow.complete();
+      await firstLogin;
+    });
+
+    test('skips re-delivered invitation_code only after successful login',
+        () async {
+      var authorizeCallCount = 0;
+
+      TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(flutterAppauth, (methodCall) async {
+        if (methodCall.method == 'authorizeAndExchangeCode') {
+          authorizeCallCount++;
+          return tokenResponseMap;
+        }
+        if (methodCall.method == 'authorize') {
+          return authorizeResponse;
+        }
+        if (methodCall.method == 'token') {
+          return tokenResponseMap;
+        }
+        if (methodCall.method == 'endSession') {
+          return endSessionResponse;
+        }
+        return null;
+      });
+
+      const invitationCode = 'invite-code-success';
+
+      await KindeFlutterSDK.instance
+          .handleInvitationCode(invitationCode);
+      expect(authorizeCallCount, 1);
+      expect(KindeFlutterSDK.instance.authState, isNotNull);
+
+      await KindeFlutterSDK.instance
+          .handleInvitationCode(invitationCode);
+      expect(authorizeCallCount, 1);
+    });
+
+    test('allows invitation_code retry after failed login', () async {
+      var authorizeCallCount = 0;
+      var failNextAuthorize = true;
+
+      TestWidgetsFlutterBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(flutterAppauth, (methodCall) async {
+        if (methodCall.method == 'authorizeAndExchangeCode') {
+          authorizeCallCount++;
+          if (failNextAuthorize) {
+            throw PlatformException(
+              code: 'authorize_failed',
+              message: 'Simulated transient failure',
+            );
+          }
+          return tokenResponseMap;
+        }
+        if (methodCall.method == 'authorize') {
+          return authorizeResponse;
+        }
+        if (methodCall.method == 'token') {
+          return tokenResponseMap;
+        }
+        if (methodCall.method == 'endSession') {
+          return endSessionResponse;
+        }
+        return null;
+      });
+
+      const invitationCode = 'invite-code-retry';
+
+      await KindeFlutterSDK.instance
+          .handleInvitationCode(invitationCode);
+      expect(authorizeCallCount, 1);
+      expect(KindeFlutterSDK.instance.authState, isNull);
+
+      failNextAuthorize = false;
+
+      await KindeFlutterSDK.instance
+          .handleInvitationCode(invitationCode);
+      expect(authorizeCallCount, 2);
+      expect(KindeFlutterSDK.instance.authState, isNotNull);
+
+      await KindeFlutterSDK.instance
+          .handleInvitationCode(invitationCode);
+      expect(authorizeCallCount, 2);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

A small subset of users hit Kinde's hosted **"This link has expired."** page (rendered inside the app's browser tab) after upgrading to **v2.1.0**, on both Enterprise SSO and email/password. Root cause is the new invitation deep-link listener auto-launching a second, concurrent authorization request that supersedes the first. When a superseded/consumed authorize link is then completed, Kinde rejects it ("link expired" / "action could only be executed once"; client-side: "state did not match").

This PR hardens the native login path in `lib/src/kinde_flutter_sdk.dart`:

- **Concurrency guard (`_loginInProgress`)** in `_handleOtherLogin` — rejects a second authorize request while one is already in flight (double-tap, interrupted-and-retried login, or the invitation listener racing a user-initiated login).
- **Invitation-code de-dup (`_lastHandledInvitationCode`)** — the OS can re-deliver the same invitation deep link (app resume, re-open, redelivery after sign-in). Without this, each redelivery re-fired `login()` with an already-consumed code → the expired-link page. Repeats are now skipped.
- **Always reset dedup on logout** — the reset runs at the top of `logout()` before the early `authState == null` return, so a failed invitation login (which may never establish a session) still clears state and lets a fresh invite be processed later.