### PR TITLE
Fix/reload auth state race

### DIFF
--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -601,11 +601,14 @@ class KindeFlutterSDK with TokenUtils {
   }
 
   Future<String?> getToken({bool forceRefresh = false}) async {
-    /// This is important to ensure we have the latest tokens before performing
-    /// checks or refresh operations with the tokens.
-    /// This is especially important for apps with concurrent background tasks
-    /// using isolates that don't have access to the latest cached state
-    await _store.reloadAuthState();
+    // Only read from disk when there is no cached state (cold start / isolate
+    // with no shared memory). Reloading unconditionally overwrites a freshly
+    // rotated token that is still being written to disk by the fire-and-forget
+    // write in Store.authState, causing the stale token to be sent to Kinde
+    // and triggering an invalid_grant error.
+    if (_store.authState == null) {
+      await _store.reloadAuthState();
+    }
 
     // Return existing token if authenticated and not forcing refresh
     if (!forceRefresh && await isAuthenticated()) {

--- a/test/get_token_reload_guard_test.dart
+++ b/test/get_token_reload_guard_test.dart
@@ -1,0 +1,83 @@
+// Tests for the reloadAuthState() guard in getToken().
+//
+// Bug (origin/main): getToken() called reloadAuthState() unconditionally, which
+// read the (potentially stale) on-disk state and overwrote the freshly rotated
+// in-memory token that the background refresh had just written. The Store
+// authState setter uses a fire-and-forget disk write, so the disk copy lags
+// behind memory during the write window — unconditionally reloading from disk
+// during that window destroys the fresh token and causes an invalid_grant error.
+//
+// Fix (this branch): reloadAuthState() is skipped when _store.authState is
+// already populated. It is only called on cold start (authState == null) to
+// restore persisted state from disk, which is the original intent.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kinde_flutter_sdk/kinde_flutter_sdk.dart';
+import 'package:kinde_flutter_sdk/src/kinde_flutter_sdk.dart';
+import 'package:kinde_flutter_sdk/src/store/store.dart';
+import 'package:kinde_flutter_sdk/src/token/auth_state.dart';
+
+import 'mock_channels.dart';
+import 'test_helpers/dio_adapter.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  mockChannels.setupMockChannel();
+
+  group('getToken reloadAuthState guard', () {
+    late KindeFlutterSDK sdk;
+
+    setUp(() async {
+      // Each test gets a fresh SDK + Store (Store.init() replaces the singleton).
+      // loadFromStorage() reads from disk; the secure-storage mock returns null,
+      // so Store.instance.authState starts as null after initialization.
+      sdk = await initializeKindeFlutterSdkForTest(
+        authDomain: 'authDomain',
+        authClientId: 'authClientId',
+        loginRedirectUri: 'loginRedirectUri',
+        logoutRedirectUri: 'logoutRedirectUri',
+        dio: setupDioMock(),
+      );
+    });
+
+    test('returns in-memory token without reloading from disk', () async {
+      // Inject a valid, non-expired auth state directly into the in-memory cache.
+      // This simulates the state left by a completed background token refresh
+      // whose fire-and-forget disk write has not yet finished.
+      Store.instance.authState = AuthState(
+        accessToken: 'rotated_access_token',
+        refreshToken: 'rotated_refresh_token',
+        accessTokenExpirationDateTime:
+            DateTime.now().add(const Duration(hours: 1)),
+        idToken: 'rotated_id_token',
+        scope: 'openid profile email offline',
+      );
+
+      // The secure-storage mock returns null for ALL reads.
+      // If getToken called reloadAuthState() unconditionally (the bug), it would:
+      //   1. Overwrite _cachedAuthState with null (disk returns null)
+      //   2. isAuthenticated() → false
+      //   3. Attempt token refresh → no refresh token → throw KindeError
+      //
+      // With the fix, authState != null so reloadAuthState() is skipped and the
+      // fresh in-memory token is returned directly.
+      final token = await sdk.getToken();
+
+      expect(token, equals('rotated_access_token'));
+    });
+
+    test('reads from disk when no auth state is cached (cold start)', () async {
+      // After initializeKindeFlutterSdkForTest the store is fresh with no cached
+      // state (mock disk returns null). This verifies the guard does NOT prevent
+      // the cold-start disk read — only the redundant read while memory is warm.
+      expect(Store.instance.authState, isNull);
+
+      // getToken() sees authState == null → calls reloadAuthState().
+      // reloadAuthState() reads null from disk → authState remains null.
+      // isAuthenticated() → false, no refresh token → throws KindeError.
+      expect(
+        () => sdk.getToken(),
+        throwsA(isA<KindeError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Explain your changes

## Bug

`getToken()` called `_store.reloadAuthState()` unconditionally on every invocation. `Store.authState` uses a fire-and-forget disk write — the setter updates the in-memory cache immediately but does not await the `flutter_secure_storage` warite:

```dart
set authState(AuthState? value) {
  _cachedAuthState = value;   // immediate
  _writeAuthState(value);     // unawaited — disk lags behind
}
```

When the background refresh timer rotated a token and then `getToken()` was called before the disk write completed, the unconditional `reloadAuthState()` read the stale (or absent) on-disk value and overwrote the freshly rotated in-memory token. The subsequent token refresh request then sent the old token to Kinde, which responded with `invalid_grant` — surfaced to users as "This link has expired".

## Fix

Guard `reloadAuthState()` so it only runs when the in-memory cache is empty:

```dart
if (_store.authState == null) {
  await _store.reloadAuthState();
}
```

This preserves the original intent — restoring persisted state on cold start or in an isolate that has no shared memory — while preventing the redundant disk read that destroyed a freshly rotated token during the fire-and-forget write window.

## Tests added

- **`returns in-memory token without reloading from disk`** — injects a valid non-expired `AuthState` into memory, confirms `getToken()` returns it directly. With the bug present the unconditional reload would wipe memory to `null` (secure-storage mock returns `null` for all reads) and throw; with the fix it returns the cached token.
- **`reads from disk when no auth state is cached (cold start)`** — confirms the guard does not block the legitimate cold-start path: when `authState` is `null`, `reloadAuthState()` is still called.

# Checklist

- [x] I have read the ["Pull requests" section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).
