### PR TITLE
feat: add reauth support

### DIFF
--- a/lib/src/additional_params.dart
+++ b/lib/src/additional_params.dart
@@ -13,7 +13,9 @@ enum Parameter {
   planInterest("plan_interest"),
   pricingTableKey("pricing_table_key"),
   invitationCode("invitation_code"),
-  isInvitation("is_invitation");
+  isInvitation("is_invitation"),
+  supportsReauth("supports_reauth"),
+  reauthState("reauth_state");
 
   const Parameter(this.value);
 
@@ -102,6 +104,8 @@ class InternalAdditionalParameters extends BaseAdditionalParameters {
   String? registrationPage;
   bool? createOrg;
   String? orgName;
+  bool? supportsReauth;
+  String? reauthState;
 
   InternalAdditionalParameters(
       {this.audience,
@@ -111,6 +115,8 @@ class InternalAdditionalParameters extends BaseAdditionalParameters {
       this.registrationPage,
       this.createOrg,
       this.orgName,
+      this.supportsReauth,
+      this.reauthState,
       super.lang,
       super.connectionId,
       super.loginHint,
@@ -156,6 +162,12 @@ class InternalAdditionalParameters extends BaseAdditionalParameters {
     }
     if (orgName != null) {
       result[Parameter.orgName.name] = orgName!;
+    }
+    if (supportsReauth != null) {
+      result[Parameter.supportsReauth.name] = supportsReauth!.toString();
+    }
+    if (reauthState != null) {
+      result[Parameter.reauthState.name] = reauthState!;
     }
     return result;
   }

--- a/lib/src/additional_params.dart
+++ b/lib/src/additional_params.dart
@@ -94,6 +94,27 @@ class AdditionalParameters extends BaseAdditionalParameters {
       super.planInterest,
       super.pricingTableKey,
       super.invitationCode});
+
+  Map<String, dynamic> toJson() => {
+        if (lang != null) 'lang': lang,
+        if (connectionId != null) 'connectionId': connectionId,
+        if (loginHint != null) 'loginHint': loginHint,
+        if (orgCode != null) 'orgCode': orgCode,
+        if (planInterest != null) 'planInterest': planInterest,
+        if (pricingTableKey != null) 'pricingTableKey': pricingTableKey,
+        if (invitationCode != null) 'invitationCode': invitationCode,
+      };
+
+  factory AdditionalParameters.fromJson(Map<String, dynamic> json) =>
+      AdditionalParameters(
+        lang: json['lang'] as String?,
+        connectionId: json['connectionId'] as String?,
+        loginHint: json['loginHint'] as String?,
+        orgCode: json['orgCode'] as String?,
+        planInterest: json['planInterest'] as String?,
+        pricingTableKey: json['pricingTableKey'] as String?,
+        invitationCode: json['invitationCode'] as String?,
+      );
 }
 
 class InternalAdditionalParameters extends BaseAdditionalParameters {
@@ -136,6 +157,18 @@ class InternalAdditionalParameters extends BaseAdditionalParameters {
       planInterest: userParams.planInterest,
       pricingTableKey: userParams.pricingTableKey,
       invitationCode: userParams.invitationCode,
+    );
+  }
+
+  AdditionalParameters toUserAdditionalParams() {
+    return AdditionalParameters(
+      lang: lang,
+      connectionId: connectionId,
+      loginHint: loginHint,
+      orgCode: orgCode,
+      planInterest: planInterest,
+      pricingTableKey: pricingTableKey,
+      invitationCode: invitationCode,
     );
   }
 

--- a/lib/src/error/kinde_error.dart
+++ b/lib/src/error/kinde_error.dart
@@ -9,6 +9,7 @@ import 'package:oauth2/oauth2.dart';
 
 part 'kinde_error_code.dart';
 part 'authorization_kinde_error.dart';
+part 'login_link_expired_kinde_error.dart';
 
 @immutable
 class KindeError implements Exception {
@@ -158,6 +159,18 @@ KindeError _flutterAppAuthExceptionMapper(
       stackTrace: stackTrace,
     );
   }
+
+  final message = platformException.message;
+  final details = platformException.details as Object?;
+
+  if (details case {'error': 'login_link_expired'}) {
+    return LoginLinkExpiredKindeError(
+      message: message,
+      details: details,
+      stackTrace: stackTrace,
+    );
+  }
+
   return KindeError(
     code: platformException.code,
     message: platformException.message,

--- a/lib/src/error/kinde_error_code.dart
+++ b/lib/src/error/kinde_error_code.dart
@@ -25,6 +25,7 @@ enum KindeErrorCode {
   refreshTokenExpired,
   sessionExpiredOrInvalid,
   userCanceled,
+  loginLinkExpired,
 
   // Configuration Errors
   missingConfig,

--- a/lib/src/error/login_link_expired_kinde_error.dart
+++ b/lib/src/error/login_link_expired_kinde_error.dart
@@ -1,0 +1,34 @@
+part of 'kinde_error.dart';
+
+/// An exception raised when the login link expires during authentication.
+///
+/// This only shows up when [InternalAdditionalParameters.supportsReauth]
+/// is enabled during an authentication request.
+class LoginLinkExpiredKindeError extends KindeError {
+  /// Platform exceptions details
+  final Map<Object?, Object?> _details;
+
+  /// The state returned with the error when the login link expires.
+  ///
+  /// Used to restart the authentication flow.
+  String? get reauthState => _extractReauthState(_details);
+
+  LoginLinkExpiredKindeError({
+    super.message,
+    required Map<Object?, Object?> details,
+    super.stackTrace,
+  }) : _details = details,
+       super(code: KindeErrorCode.loginLinkExpired.code);
+
+  /// Extracts the [reauth_state] from the error details.
+  ///
+  /// Note, this only extracts from the iOS error details.
+  /// This is because the Android SDK, AppAuth-Android, doesn't currently
+  /// return query params in the [PlatformException.details]
+  static String? _extractReauthState(Map<Object?, Object?> details) {
+    final match = RegExp(
+      r'"reauth_state"\s*=\s*"([^"]+)"',
+    ).firstMatch(details.toString());
+    return match?.group(1);
+  }
+}

--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -790,12 +790,12 @@ class KindeFlutterSDK with TokenUtils {
     );
     WebUtils.setSessionItem(_webAuthRetriedFlag, 'true');
 
-    _handleWebLogin(
-      InternalAdditionalParameters(
-        supportsReauth: true,
-        reauthState: reauthState,
-      ),
+    final params = _prepareInternalAdditionalParameters(
+      const AdditionalParameters(),
     );
+    params.reauthState = reauthState;
+
+    _handleWebLogin(params);
   }
 
   ///returns current url if it contain required params for finishing auth flow

--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -397,6 +397,7 @@ class KindeFlutterSDK with TokenUtils {
         InternalAdditionalParameters.fromUserAdditionalParams(additionalParams);
     internalAdditionalParams.audience = _config!.audience;
     internalAdditionalParams.scopes = _config!.scopes;
+    internalAdditionalParams.supportsReauth = true;
     return internalAdditionalParams;
   }
 

--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -785,12 +785,16 @@ class KindeFlutterSDK with TokenUtils {
     WebUtils.removeSessionItem(_webAuthRetriedFlag);
 
     if (hasAlreadyRetried) {
+      const errorMessage =
+          "Reauth retry already attempted. Aborting to prevent infinite loop.";
       kindeDebugPrint(
         methodName: "_handleExpiredWebLogin",
-        message:
-            "Reauth retry already attempted. Aborting to prevent infinite loop.",
+        message: errorMessage,
       );
-      return;
+      throw LoginLinkExpiredKindeError(
+        message: errorMessage,
+        details: {'reauth_state': reauthState},
+      );
     }
 
     kindeDebugPrint(

--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -557,6 +557,7 @@ class KindeFlutterSDK with TokenUtils {
 
   Future<bool> _finishWebLogin(String responseUrl) async {
     WebUtils.removeSessionItem(_webSavedParamsKey);
+    WebUtils.removeSessionItem(_webAuthRetriedFlag);
     final credentials = await KindeWeb.instance.finishLoginFlow(
         scopes: _config!.scopes,
         redirectUrl: _config!.loginRedirectUri,

--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 
@@ -63,6 +64,9 @@ class KindeFlutterSDK with TokenUtils {
 
   /// SessionStorage key used to prevent infinite reauth retries on Web.
   static const _webAuthRetriedFlag = 'kinde_web_auth_retried';
+
+  /// SessionStorage key used to preserve custom AdditionalParameters across Web redirects/retries.
+  static const _webSavedParamsKey = 'kinde_web_saved_additional_params';
 
   static KindeFlutterSDK get instance {
     return _instance ??= KindeFlutterSDK._internal();
@@ -536,6 +540,10 @@ class KindeFlutterSDK with TokenUtils {
   void _handleWebLogin(
     InternalAdditionalParameters params,
   ) {
+    WebUtils.setSessionItem(
+      _webSavedParamsKey,
+      jsonEncode(params.toUserAdditionalParams().toJson()),
+    );
     KindeWeb.instance.startLoginFlow(
         AuthorizationRequest(
           _config!.authClientId,
@@ -548,6 +556,7 @@ class KindeFlutterSDK with TokenUtils {
   }
 
   Future<bool> _finishWebLogin(String responseUrl) async {
+    WebUtils.removeSessionItem(_webSavedParamsKey);
     final credentials = await KindeWeb.instance.finishLoginFlow(
         scopes: _config!.scopes,
         redirectUrl: _config!.loginRedirectUri,
@@ -790,9 +799,14 @@ class KindeFlutterSDK with TokenUtils {
     );
     WebUtils.setSessionItem(_webAuthRetriedFlag, 'true');
 
-    final params = _prepareInternalAdditionalParameters(
-      const AdditionalParameters(),
-    );
+    final savedParamsJson = WebUtils.getSessionItem(_webSavedParamsKey);
+    final recoveredUserParams =
+        savedParamsJson != null && savedParamsJson.isNotEmpty
+            ? AdditionalParameters.fromJson(
+                jsonDecode(savedParamsJson) as Map<String, dynamic>)
+            : const AdditionalParameters();
+
+    final params = _prepareInternalAdditionalParameters(recoveredUserParams);
     params.reauthState = reauthState;
 
     _handleWebLogin(params);

--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 
 import 'package:kinde_flutter_sdk/src/additional_params.dart';
 import 'package:kinde_flutter_sdk/src/kinde_secure_storage/kinde_secure_storage_i.dart';
+import 'package:kinde_flutter_sdk/src/utils/app_lifecycle_util.dart';
 import 'package:kinde_flutter_sdk/src/utils/deep_link_util.dart';
 import 'package:kinde_flutter_sdk/src/utils/kinde_custom_types.dart';
 import 'package:kinde_flutter_sdk/src/utils/kinde_debug_print.dart';
@@ -59,6 +60,9 @@ class KindeFlutterSDK with TokenUtils {
 
   bool _handlingInvitationCode = false;
   StreamSubscription<Uri>? _deepLinkSubscription;
+
+  /// SessionStorage key used to prevent infinite reauth retries on Web.
+  static const _webAuthRetriedFlag = 'kinde_web_auth_retried';
 
   static KindeFlutterSDK get instance {
     return _instance ??= KindeFlutterSDK._internal();
@@ -409,14 +413,18 @@ class KindeFlutterSDK with TokenUtils {
     if (kIsWeb) {
       _handleWebLogin(internalAdditionalParameters);
     } else {
-      return _handleOtherLogin(type, internalAdditionalParameters);
+      return _handleOtherLogin(type, internalAdditionalParameters, isRetrying: false,);
     }
     return null;
   }
 
-  //MacOs, Android, IOS
+  /// Handles login for macOS, Android and iOS
+  ///
+  /// [isRetrying] tracks if we are retrying the authentication flow.
+  /// We currently only retry once if the login link has expired.
+  ///
   Future<String?> _handleOtherLogin(
-    AuthFlowType? type, InternalAdditionalParameters params) async {
+    AuthFlowType? type, InternalAdditionalParameters params, {required bool isRetrying,}) async {
     const appAuth = FlutterAppAuth();
     TokenResponse tokenResponse;
     try {
@@ -443,12 +451,40 @@ class KindeFlutterSDK with TokenUtils {
       _saveState(tokenResponse);
       return tokenResponse.accessToken;
     } catch (e, st) {
+      final kindeError = KindeError.fromError(e, st);
+
+      // Only retry once if the login link has expired
+      // If we're already in a retry, do not retry again.
+      if (kindeError is LoginLinkExpiredKindeError && !isRetrying) {
+        /// Currently On Android, `reauthState` is null,
+        /// but this is fine since have the original `params` object.
+        /// See `LoginLinkExpiredKindeError._extractReauthState` for more details.
+        final reauthState = kindeError.reauthState;
+
+        params.reauthState = reauthState;
+
+        // Since the app is being reopened from the expired login link,
+        // we need to ensure it is in the foreground before attempting to
+        // retry the authentication flow.
+        final isForeground = await AppLifecycleUtil.ensureAppIsInForeground();
+
+        if (isForeground) {
+          return _handleOtherLogin(type, params, isRetrying: true);
+        } else {
+          kindeDebugPrint(
+            methodName: '_handleOtherLogin',
+            message:
+                'App did not return to foreground in time. Aborting retry.',
+          );
+        }
+      }
+
       kindeDebugPrint(
         methodName: '_handleOtherLogin',
         message: 'Authentication failed',
         context: {'flowType': type?.name ?? 'default', 'error': e.toString()},
       );
-      throw KindeError.fromError(e, st);
+      throw kindeError;
     }
   }
 
@@ -708,7 +744,21 @@ class KindeFlutterSDK with TokenUtils {
   ///
   /// Call this **before** checking authentication status.
   Future<bool> completePendingLoginIfNeeded() async {
-    final finishLoginUri = _isCurrentUrlContainWebAuthParams();
+    final currentUrl = WebUtils.getCurrentUrl ?? "";
+    final currentUri = Uri.tryParse(currentUrl);
+
+    /// Check if this is an expired login link, retrieving the reauth_state
+    if (currentUri?.queryParameters case {
+      'error': 'login_link_expired',
+      'reauth_state': String reauthState,
+    }) {
+      _handleExpiredWebLogin(reauthState: reauthState);
+      /// Returning false because we aren't actually completing the auth process here
+      /// We're rather retrying the flow if expired
+      return false;
+    }
+
+    final finishLoginUri = _isCurrentUrlContainWebAuthParams(currentUrl: currentUrl);
     if (finishLoginUri != null) {
       final storedState = await _kindeSecureStorage.getAuthRequestState();
       if (storedState != null) {
@@ -718,10 +768,39 @@ class KindeFlutterSDK with TokenUtils {
     return false;
   }
 
+  void _handleExpiredWebLogin({required String reauthState}) {
+    final hasAlreadyRetried =
+        WebUtils.getSessionItem(_webAuthRetriedFlag) == 'true';
+
+    // Clear retry flag after retrieval
+    WebUtils.removeSessionItem(_webAuthRetriedFlag);
+
+    if (hasAlreadyRetried) {
+      kindeDebugPrint(
+        methodName: "_handleExpiredWebLogin",
+        message:
+            "Reauth retry already attempted. Aborting to prevent infinite loop.",
+      );
+      return;
+    }
+
+    kindeDebugPrint(
+      methodName: "_handleExpiredWebLogin",
+      message: "Login link expired on Web. Retrying login with reauth_state...",
+    );
+    WebUtils.setSessionItem(_webAuthRetriedFlag, 'true');
+
+    _handleWebLogin(
+      InternalAdditionalParameters(
+        supportsReauth: true,
+        reauthState: reauthState,
+      ),
+    );
+  }
+
   ///returns current url if it contain required params for finishing auth flow
-  String? _isCurrentUrlContainWebAuthParams() {
+  String? _isCurrentUrlContainWebAuthParams({required String currentUrl}) {
     if (kIsWeb && authState == null) {
-      final currentUrl = WebUtils.getCurrentUrl ?? "";
       if (currentUrl.isEmpty) return null;
       final currentUri = Uri.tryParse(currentUrl);
       if (currentUri == null || !currentUri.hasScheme) return null;

--- a/lib/src/kinde_web/src/utils/cross_platform_support_noop.dart
+++ b/lib/src/kinde_web/src/utils/cross_platform_support_noop.dart
@@ -9,4 +9,10 @@ abstract class WebUtils {
   static String? get getOriginUrl => null;
 
   static String get temporaryDirectory => "";
+
+  static String? getSessionItem(String key) => null;
+
+  static void setSessionItem(String key, String value) {}
+
+  static void removeSessionItem(String key) {}
 }

--- a/lib/src/kinde_web/src/utils/web_utils.dart
+++ b/lib/src/kinde_web/src/utils/web_utils.dart
@@ -13,4 +13,13 @@ abstract class WebUtils {
 
   static String get temporaryDirectory =>
       window.localStorage.getItem('temporary_directory') ?? "";
+
+  static String? getSessionItem(String key) =>
+      window.sessionStorage.getItem(key);
+
+  static void setSessionItem(String key, String value) =>
+      window.sessionStorage.setItem(key, value);
+
+  static void removeSessionItem(String key) =>
+      window.sessionStorage.removeItem(key);
 }

--- a/lib/src/utils/app_lifecycle_util.dart
+++ b/lib/src/utils/app_lifecycle_util.dart
@@ -1,0 +1,58 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+/// A utility class for handling app lifecycle events.
+class AppLifecycleUtil {
+  /// Ensures that the app is in the foreground.
+  ///
+  /// Returns `true` if the app is resumed (or transitions to resumed within the [timeout]),
+  /// or `false` if the [timeout] expires while the app is not in the foreground.
+  static Future<bool> ensureAppIsInForeground({
+    Duration timeout = const Duration(seconds: 3),
+  }) async {
+    final state = WidgetsBinding.instance.lifecycleState;
+
+    if (state == AppLifecycleState.resumed) {
+      return true;
+    }
+
+    final completer = Completer<bool>();
+
+    final resumedLifecycleObserver = _ResumedLifecycleObserver(
+      onResumed: () {
+        if (!completer.isCompleted) {
+          completer.complete(true);
+        }
+      },
+    );
+
+    WidgetsBinding.instance.addObserver(resumedLifecycleObserver);
+
+    final isResumed = await completer.future.timeout(
+      timeout,
+      onTimeout: () => false,
+    );
+
+    WidgetsBinding.instance.removeObserver(resumedLifecycleObserver);
+
+    return isResumed;
+  }
+}
+
+/// A lifecycle observer that listens for the app to be resumed.
+///
+/// When the app is resumed, it calls the [onResumed] callback.
+class _ResumedLifecycleObserver extends WidgetsBindingObserver {
+  _ResumedLifecycleObserver({required this.onResumed});
+
+  final VoidCallback onResumed;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      onResumed();
+    }
+  }
+}
+

--- a/test/error/kinde_error_code_test.dart
+++ b/test/error/kinde_error_code_test.dart
@@ -4,8 +4,8 @@ import 'package:kinde_flutter_sdk/src/error/kinde_error.dart';
 void main() {
   group('KindeErrorCode Enum', () {
     group('Basic Enum Properties', () {
-      test('should have exactly 17 error codes', () {
-        expect(KindeErrorCode.values.length, 17);
+      test('should have exactly 18 error codes', () {
+        expect(KindeErrorCode.values.length, 18);
       });
 
       test('should convert camelCase enum names to kebab-case strings', () {
@@ -31,6 +31,7 @@ void main() {
         expect(KindeErrorCode.unsupportedScheme.code, 'unsupported-scheme');
         expect(KindeErrorCode.portalLinkUrlIsNull.code, 'portal-link-url-is-null');
         expect(KindeErrorCode.loginInProcess.code, 'login-in-process');
+        expect(KindeErrorCode.loginLinkExpired.code, 'login-link-expired');
         expect(KindeErrorCode.unknown.code, 'unknown');
       });
 
@@ -81,6 +82,8 @@ void main() {
             KindeErrorCode.refreshTokenExpired);
         expect(KindeErrorCode.fromString('session-expired-or-invalid'),
             KindeErrorCode.sessionExpiredOrInvalid);
+        expect(KindeErrorCode.fromString('login-link-expired'),
+            KindeErrorCode.loginLinkExpired);
         expect(
             KindeErrorCode.fromString('unknown'), KindeErrorCode.unknown);
       });

--- a/test/error/login_link_expired_kinde_error_test.dart
+++ b/test/error/login_link_expired_kinde_error_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kinde_flutter_sdk/src/error/kinde_error.dart';
+
+void main() {
+  group('LoginLinkExpiredKindeError reauthState', () {
+    test('extracts reauthState from iOS NSError debug description string', () {
+      final details = {
+        'error': 'login_link_expired',
+        'error_debug_description':
+            'Error Domain=org.openid.appauth.general Code=-61440 "login_link_expired" UserInfo={\n'
+            '    NSLocalizedDescription = "login_link_expired";\n'
+            '    OIDOAuthErrorResponseErrorKey = \'AuthorizationErrorResponse: { error = "login_link_expired"; "reauth_state" = "sample_ios_reauth_token_123"; }\';\n'
+            '}',
+      };
+
+      final error = LoginLinkExpiredKindeError(details: details);
+
+      expect(error.reauthState, 'sample_ios_reauth_token_123');
+      expect(error.code, KindeErrorCode.loginLinkExpired.code);
+    });
+
+    test(
+      'extracts reauthState from Android AuthorizationException string',
+      () {},
+      skip:
+          'Skipping as the underlying Android library, AppAuth-Android currently doesn\'t return the reauth_state in the error response',
+    );
+
+    test('returns null when reauth_state is not present in details', () {
+      const details = {
+        'error': 'login_link_expired',
+        'error_description': 'Login link has expired',
+      };
+
+      final error = LoginLinkExpiredKindeError(details: details);
+
+      expect(error.reauthState, isNull);
+    });
+  });
+}


### PR DESCRIPTION
# Explain your changes

This PR adds reauth support to the SDK. 

It sets `support_reauth` to true in the auth URL. 

This makes the browser navigate back to the app when an expired link is encountered. 

Then the app retries the authentication request once using the `reauth_state` returned in the error url. 

Note: On Android, currently we can't get the `reauth_state` because the underlying SDK, `AppAuth-Android` doesn't include the error query params when an error is detected. This is not an issue, though, since we have the original `params` object from the initial request and it's used for the retry. 



# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
