### PR TITLE
revert: PR #64 (restore EndSessionRequest workaround and SDK bounds)

### DIFF
--- a/lib/src/auth/kinde_end_session_request.dart
+++ b/lib/src/auth/kinde_end_session_request.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_appauth/flutter_appauth.dart';
+
+/// A custom [EndSessionRequest] implementation used to bypass
+/// `flutter_appauth`'s [EndSessionRequest] assertion that requires both
+/// [idTokenHint] and [postLogoutRedirectUrl] to be either both null or both
+/// non-null.
+///
+/// This is required so we can omit [idTokenHint] when we pass the
+/// [postLogoutRedirectUrl]. We now pass the [client_id] as part of
+/// [additionalParameters] instead.
+///
+/// Omitting [idTokenHint] prevents 414 Request-URI Too Large errors caused by
+/// appending a potentially large idToken to the logout URL.
+///
+/// TODO: This class should be removed when `flutter_appauth` is upgraded to >=12.0.1, (as that version
+/// removes the `idTokenHint` assertion from [EndSessionRequest]) so that [EndSessionRequest] can
+/// be used directly.
+///
+/// See:
+/// - [flutter_appauth CHANGELOG](https://github.com/MaikuB/flutter_appauth/blob/master/flutter_appauth/CHANGELOG.md#1201)
+/// - [PR implementing this](https://github.com/kinde-oss/kinde-flutter-sdk/pull/64)
+class KindeEndSessionRequest implements EndSessionRequest {
+  @override
+  final String? idTokenHint;
+  @override
+  final String? postLogoutRedirectUrl;
+  @override
+  final String? state;
+  @override
+  bool allowInsecureConnections;
+  @override
+  ExternalUserAgent? externalUserAgent;
+  @override
+  final Map<String, String>? additionalParameters;
+  @override
+  AuthorizationServiceConfiguration? serviceConfiguration;
+  @override
+  String? issuer;
+  @override
+  String? discoveryUrl;
+
+  KindeEndSessionRequest({
+    this.idTokenHint,
+    this.postLogoutRedirectUrl,
+    this.state,
+    this.allowInsecureConnections = false,
+    this.externalUserAgent = ExternalUserAgent.asWebAuthenticationSession,
+    this.additionalParameters,
+    this.serviceConfiguration,
+    this.issuer,
+    this.discoveryUrl,
+  });
+
+  @override
+  void assertConfigurationInfo() {
+    assert(
+      issuer != null || discoveryUrl != null || serviceConfiguration != null,
+      'Either the issuer, discovery URL or service configuration must be '
+      'provided',
+    );
+  }
+}

--- a/lib/src/kinde_flutter_sdk.dart
+++ b/lib/src/kinde_flutter_sdk.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:kinde_flutter_sdk/src/additional_params.dart';
+import 'package:kinde_flutter_sdk/src/auth/kinde_end_session_request.dart';
 import 'package:kinde_flutter_sdk/src/kinde_secure_storage/kinde_secure_storage_i.dart';
 import 'package:kinde_flutter_sdk/src/utils/app_lifecycle_util.dart';
 import 'package:kinde_flutter_sdk/src/utils/deep_link_util.dart';
@@ -299,7 +300,8 @@ class KindeFlutterSDK with TokenUtils {
       //
       // We instead pass the `client_id` as part of `additionalParameters`.
       //
-      final endSessionRequest = EndSessionRequest(
+      // See the [KindeEndSessionRequest] class documentation for more information.
+      final endSessionRequest = KindeEndSessionRequest(
         externalUserAgent:
             ExternalUserAgent.ephemeralAsWebAuthenticationSession,
         postLogoutRedirectUrl: _config!.logoutRedirectUri,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -306,18 +306,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_appauth
-      sha256: d8be972036909e99c022bbb8edcad126dbd2cbaceaa2eb85e35791b599f3e9cf
+      sha256: "0aa449d8991f70e7847d55b8bff0890fb41dc62c1d8526337e4073e806813bcb"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.1"
+    version: "8.0.3"
   flutter_appauth_platform_interface:
     dependency: transitive
     description:
       name: flutter_appauth_platform_interface
-      sha256: b7c7d4f288af7b3119a9db0ea00cf5e93135d0e83c3687172848bc5c4fdec992
+      sha256: ccf5e1d8c40dd35b297290b33cc1896648b4b92a2ec3f62a436c62a8eef9a9db
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.1"
+    version: "8.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ platforms:
   web:
 
 environment:
-  sdk: '>=3.10.0 <4.0.0'
-  flutter: '>=3.38.1'
+  sdk: '>=3.9.2 <4.0.0'
+  flutter: '>=3.35.6'
 
 dependencies:
   flutter:
@@ -19,7 +19,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
 
-  flutter_appauth: ^12.0.1
+  flutter_appauth: ^8.0.3
   flutter_secure_storage: ^10.3.0
   path_provider: ^2.1.4
   dio: ^5.7.0

--- a/test/src/auth/kinde_end_session_request_test.dart
+++ b/test/src/auth/kinde_end_session_request_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_appauth/flutter_appauth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kinde_flutter_sdk/src/auth/kinde_end_session_request.dart';
+
+void main() {
+  group("KindeEndSessionRequest", () {
+    group("constructor", () {
+      test("does not throw assertion error if both "
+          "idTokenHint and postLogoutRedirectUrl are null", () {
+        expect(
+          () => KindeEndSessionRequest(
+            idTokenHint: null,
+            postLogoutRedirectUrl: null,
+          ),
+          isNot(throwsAssertionError),
+        );
+      });
+
+      test("does not throw assertion error if idTokenHint is non-null but "
+          "postLogoutRedirectUrl is null", () {
+        expect(
+          () => KindeEndSessionRequest(
+            idTokenHint: 'idTokenHint',
+            postLogoutRedirectUrl: null,
+          ),
+          isNot(throwsAssertionError),
+        );
+      });
+
+      test(
+        "does not throw assertion error if postLogoutRedirectUrl is non-null but "
+        "idTokenHint is null",
+        () {
+          expect(
+            () => KindeEndSessionRequest(
+              idTokenHint: null,
+              postLogoutRedirectUrl: 'postLogoutRedirectUrl',
+            ),
+            isNot(throwsAssertionError),
+          );
+        },
+      );
+
+      test("does not throw assertion error if both "
+          "idTokenHint and postLogoutRedirectUrl are non-null", () {
+        expect(
+          () => KindeEndSessionRequest(
+            idTokenHint: 'idTokenHint',
+            postLogoutRedirectUrl: 'postLogoutRedirectUrl',
+          ),
+          isNot(throwsAssertionError),
+        );
+      });
+    });
+
+    group("assertConfigurationInfo", () {
+      test("throws exception if no configuration "
+          "information is provided", () {
+        expect(
+          () => KindeEndSessionRequest().assertConfigurationInfo(),
+          throwsAssertionError,
+        );
+      });
+
+      test("does not throw exception if issuer is provided", () {
+        expect(
+          () => KindeEndSessionRequest(
+            issuer: 'issuer',
+          ).assertConfigurationInfo(),
+          isNot(throwsAssertionError),
+        );
+      });
+
+      test("does not throw exception if discoveryUrl is provided", () {
+        expect(
+          () => KindeEndSessionRequest(
+            discoveryUrl: 'discoveryUrl',
+          ).assertConfigurationInfo(),
+          isNot(throwsAssertionError),
+        );
+      });
+
+      test("does not throw exception if serviceConfiguration is provided", () {
+        expect(
+          () => KindeEndSessionRequest(
+            serviceConfiguration: const AuthorizationServiceConfiguration(
+              authorizationEndpoint: 'authorizationEndpoint',
+              tokenEndpoint: 'tokenEndpoint',
+            ),
+          ).assertConfigurationInfo(),
+          isNot(throwsAssertionError),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
# Explain your changes

This PR reverts PR #64 to avoid the Dart/Flutter version bumps caused as a result of the `flutter_appauth` upgrade. 

The upgrade will be done in a separate task/PR.

This PR is a copy of #63 which is already merged and approved.



# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
